### PR TITLE
Modified medium links

### DIFF
--- a/src/components/ui/Footer/AboutMyCrypto/Socials/Socials.tsx
+++ b/src/components/ui/Footer/AboutMyCrypto/Socials/Socials.tsx
@@ -14,7 +14,7 @@ const SOCIAL_MEDIA_LINKS: Array<{ url: string; icon: keyof typeof icons }> = [
     icon: 'facebook'
   },
   {
-    url: 'https://medium.com/@mycrypto',
+    url: 'https://medium.com/mycrypto',
     icon: 'medium'
   },
   {

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -12,7 +12,7 @@ export const LEFT_HEADER_ITEMS: HeaderItem[] = [
   },
   {
     title: 'Latest news',
-    to: 'https://medium.com/@mycrypto',
+    to: 'https://medium.com/mycrypto',
     external: true
   }
 ];


### PR DESCRIPTION
* Modified links to go to mycrypto publication instead of mycrypto user on Medium
  * This will show us all the articles published on MyCrypto https://medium.com/mycrypto (publication) rather than https://medium.com/@mycrypto (user)