### PR TITLE
Move related articles to frontmatter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,8 +34,7 @@
         "plugin:@typescript-eslint/recommended",
         "plugin:eslint-plugin-react/recommended",
         "plugin:eslint-plugin-react-hooks/recommended",
-        "plugin:eslint-plugin-import/typescript",
-        "eslint-config-prettier/@typescript-eslint"
+        "plugin:eslint-plugin-import/typescript"
       ],
       "plugins": ["@typescript-eslint"],
       "rules": {

--- a/src/components/PageArticles/PageArticles.tsx
+++ b/src/components/PageArticles/PageArticles.tsx
@@ -1,0 +1,27 @@
+import { FunctionComponent } from 'react';
+import { RelatedArticle } from '../../types/page';
+import Link from '../Link';
+import H2 from '../markdown/default/H2';
+import ListItem from '../markdown/default/List/ListItem';
+import UnorderedList from '../markdown/default/List/UnorderedList';
+
+export interface Props {
+  relatedArticles: RelatedArticle[];
+}
+
+const PageArticles: FunctionComponent<Props> = ({ relatedArticles }) => (
+  <>
+    <H2>Related Articles</H2>
+    <UnorderedList>
+      {relatedArticles.map((relatedArticle) => (
+        <ListItem key={relatedArticle.url}>
+          <Link to={relatedArticle.url} external={!relatedArticle.isRelative}>
+            {relatedArticle.title}
+          </Link>
+        </ListItem>
+      ))}
+    </UnorderedList>
+  </>
+);
+
+export default PageArticles;

--- a/src/components/PageArticles/index.ts
+++ b/src/components/PageArticles/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PageArticles';

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -3,6 +3,7 @@ import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import Breadcrumbs from '../components/Breadcrumbs';
 import MetaData from '../components/MetaData';
+import PageArticles from '../components/PageArticles';
 import PageBody from '../components/PageBody';
 import PageFooter from '../components/PageFooter/PageFooter';
 import PageHeader from '../components/PageHeader/PageHeader';
@@ -55,6 +56,7 @@ const Page: FunctionComponent<Props> = ({ data: { mdx } }) => (
               dateModified={mdx.frontmatter.dateModified}
             />
             <PageBody body={mdx.body} />
+            {mdx.relatedArticles && <PageArticles relatedArticles={mdx.relatedArticles} />}
           </Article>
           <PageSidebar />
         </Wrapper>
@@ -80,6 +82,11 @@ export const query = graphql`
       breadcrumbs {
         title
         slug
+      }
+      relatedArticles {
+        title
+        url
+        isRelative
       }
     }
   }

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -21,6 +21,7 @@ export interface Mdx {
   wordCount: string;
   category: Yaml;
   breadcrumbs: Breadcrumb[];
+  relatedArticles: RelatedArticle[];
 }
 
 interface MdxFrontmatter {
@@ -29,6 +30,7 @@ interface MdxFrontmatter {
   tags: string[];
   datePublished: string;
   dateModified: string;
+  related_articles?: Array<string | RelatedArticle>;
 }
 
 interface MdxHeading {
@@ -48,3 +50,9 @@ export interface PageResult {
 }
 
 export type SearchResult = Pick<Mdx, 'slug' | 'excerpt'> & { title: string; tags: string[] };
+
+export interface RelatedArticle {
+  title: string;
+  url: string;
+  isRelative?: boolean;
+}


### PR DESCRIPTION
Related articles can now be specified in the frontmatter, rather than in the article content directly. This makes it possible to standardise the design for related articles in the redesign.

Related articles are specified like this:
```yml
related_articles:
  # Internal links - the title is automatically fetched
  - how-to/tokens/showing-and-loading-tokens
  - developers/add-token-to-default-list
  - how-to/getting-started/how-to-buy-btc-with-usd
  # External links - you have to specify the title manually
  - title: Foo Bar
    url: https://google.com
```